### PR TITLE
컨테이너 메모리 조정

### DIFF
--- a/.github/workflows/aws/acha-extractor-task-revision.json
+++ b/.github/workflows/aws/acha-extractor-task-revision.json
@@ -77,7 +77,7 @@
         "FARGATE"
     ],
     "cpu": "1024",
-    "memory": "3072",
+    "memory": "2048",
     "runtimePlatform": {
         "cpuArchitecture": "X86_64",
         "operatingSystemFamily": "LINUX"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - AWS ECS 작업의 메모리 할당량을 기존 3072에서 2048으로 조정했습니다. 이 변경은 컨테이너 성능 및 자원 활용에 영향을 미칠 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->